### PR TITLE
Fix Pong boundary check

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+// Basic smoke test to ensure the home page renders expected content
+test('renders homepage heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Innovative Tech Solutions/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/components/pong/Pong.jsx
+++ b/src/components/pong/Pong.jsx
@@ -211,7 +211,7 @@ export default class App extends React.Component {
     } else if (event.key === "l") {
       this.setState({ p2: this.state.p2 + step });
     }
-    if (this.checkPlayer1Boundaries() === false) {
+    if (this.checkPlayer2Boundaries() === false) {
       this.resetPlayer(2);
     }
   };


### PR DESCRIPTION
## Summary
- correct paddle 2 boundary check logic
- update the React test to look for actual homepage text

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684f067d8168832181ed793c1ffcf144