### PR TITLE
Fix footer quote typo

### DIFF
--- a/src/components/FooterComponents/Footer.jsx
+++ b/src/components/FooterComponents/Footer.jsx
@@ -25,7 +25,7 @@ const slides = [
   {
     Component: ReferenceQuote,
     props: {
-      quote: 'Excellent contactor/consultant - genuinely loves his projects.',
+      quote: 'Excellent contractor/consultant - genuinely loves his projects.',
       author:
         'Jonathan Goulstine, CEO @ Ensign Advanced Systems Ltd',
     },


### PR DESCRIPTION
## Summary
- fix the typo in the reference quote in `Footer.jsx`

## Testing
- `npm test --silent --runTestsByPath` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f08d539dc83218e8346a4d385d9e3