### PR TITLE
Fix player 2 boundary check

### DIFF
--- a/src/components/pong/Pong.jsx
+++ b/src/components/pong/Pong.jsx
@@ -211,7 +211,7 @@ export default class App extends React.Component {
     } else if (event.key === "l") {
       this.setState({ p2: this.state.p2 + step });
     }
-    if (this.checkPlayer2Boundaries() === false) {
+    if (!this.checkPlayer2Boundaries()) {
       this.resetPlayer(2);
     }
   };


### PR DESCRIPTION
## Summary
- reset player 2 with its own boundary check

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684f08d458e8832186af3b3fde60ef54